### PR TITLE
Fix Redshift multi_az setting to prevent auto-failover conflicts

### DIFF
--- a/infra/Terraform/aws_redshift.tf
+++ b/infra/Terraform/aws_redshift.tf
@@ -44,6 +44,9 @@ resource "aws_redshift_cluster" "redshift_cluster" {
   skip_final_snapshot  = true
   cluster_subnet_group_name = aws_redshift_subnet_group.redshift_subnet_group.name
   vpc_security_group_ids    = [aws_security_group.redshift_sg.id]
+  
+  # Explicitly disable multi-AZ to prevent auto-failover conflicts
+  multi_az = false
 
   tags = {
     Name = "${var.prefix}-redshift-cluster-${random_id.env_display_id.hex}"


### PR DESCRIPTION
Error that some attendees got in the workshop:
```
Error: modifying Redshift Cluster (frauddetectiondemo-redshift-cluster-a1e0325d): operation error Redshift: ModifyCluster, https response error StatusCode: 400, RequestID: 083af03c-e74e-44ec-8d71-60158d425b2c, api error InvalidParameterCombination: When a ModifyCluster AutoFailover operation is requested, no other modifications are allowed in the same request.
│ 
│   with aws_redshift_cluster.redshift_cluster,
│   on aws_redshift.tf line 37, in resource "aws_redshift_cluster" "redshift_cluster":
│   37: resource "aws_redshift_cluster" "redshift_cluster" {
```

This PR fixes it by explicitly setting multi_az = false, to prevent Terraform from attempting ModifyCluster AutoFailover operation.